### PR TITLE
fix name conflict with other plugins which have the same name "gradle…

### DIFF
--- a/source/src/main/groovy/com/kezong/fataar/VariantProcessor.groovy
+++ b/source/src/main/groovy/com/kezong/fataar/VariantProcessor.groovy
@@ -42,9 +42,12 @@ class VariantProcessor {
         mVariant = variant
         // gradle version
         mProject.parent.buildscript.getConfigurations().getByName("classpath").getDependencies().each { Dependency dep ->
-            if (dep.name == "gradle") {
+            if (dep.group == "com.android.tools.build" && dep.name == "gradle") {
                 mGradlePluginVersion = dep.version
             }
+        }
+        if (mGradlePluginVersion == null) {
+            throw new IllegalStateException("com.android.tools.build:gradle is no set in the root build.gradle file")
         }
     }
 


### PR DESCRIPTION
If you add `classpath 'io.fabric.tools:gradle:1.29.0'` below `classpath 'com.android.tools.build:gradle:3.4.2' `, then you will use wrong `mGradlePluginVersion` at `VariantProcessor`, which leads to error during gradle syncing.