### PR TITLE
fix duplicate class problem, when the java-lib module is desired to be embedded in a far-aar library

### DIFF
--- a/source/src/main/groovy/com/kezong/fataar/FatLibraryPlugin.groovy
+++ b/source/src/main/groovy/com/kezong/fataar/FatLibraryPlugin.groovy
@@ -54,6 +54,7 @@ class FatLibraryPlugin implements Plugin<Project> {
     private void createConfiguration() {
         embedConf = project.configurations.create('embed')
         embedConf.visible = false
+        embedConf.transitive = false
     }
 
     private void resolveArtifacts() {


### PR DESCRIPTION
By default `embed` configuration pulls the internal 'java-library' module dependencies into the `fat-aar`, which is not a desired behavior by default.

For instance, if you add `dagger` dependency to `:example:lib-java:build.gradle` file, that `dagger` dependency will be included into your final `fat-aar`.