### PR TITLE
Use rootProject instead of parent

### DIFF
--- a/source/src/main/groovy/com/kezong/fataar/VariantProcessor.groovy
+++ b/source/src/main/groovy/com/kezong/fataar/VariantProcessor.groovy
@@ -37,7 +37,7 @@ class VariantProcessor {
         mProject = project
         mVariant = variant
         // gradle version
-        mProject.parent.buildscript.getConfigurations().getByName("classpath").getDependencies().each { Dependency dep ->
+        mProject.rootProject.buildscript.getConfigurations().getByName("classpath").getDependencies().each { Dependency dep ->
             if (dep.group == "com.android.tools.build" && dep.name == "gradle") {
                 mGradlePluginVersion = dep.version
             }


### PR DESCRIPTION
When using this plugin in a at least two levels depth project structure it fails to detect Android Gradle tools.