### PR TITLE
Add support for specific build type and product flavor dependencies

### DIFF
--- a/source/src/main/groovy/com/kezong/fataar/ConfigurationDependencyResolutionListener.groovy
+++ b/source/src/main/groovy/com/kezong/fataar/ConfigurationDependencyResolutionListener.groovy
@@ -1,0 +1,31 @@
+package com.kezong.fataar
+
+import com.android.build.gradle.api.LibraryVariant
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.DependencyResolutionListener
+import org.gradle.api.artifacts.ResolvableDependencies
+
+class ConfigurationDependencyResolutionListener implements DependencyResolutionListener {
+
+    private final Project project
+
+    private final Configuration configuration
+
+    ConfigurationDependencyResolutionListener(Project project, Configuration configuration) {
+        this.project = project
+        this.configuration = configuration
+    }
+
+    @Override
+    void beforeResolve(ResolvableDependencies resolvableDependencies) {
+        configuration.dependencies.each { dependency ->
+            project.dependencies.add('compileOnly', dependency)
+        }
+        project.gradle.removeListener(this)
+    }
+
+    @Override
+    void afterResolve(ResolvableDependencies resolvableDependencies) {
+    }
+}

--- a/source/src/main/groovy/com/kezong/fataar/FatLibraryPlugin.groovy
+++ b/source/src/main/groovy/com/kezong/fataar/FatLibraryPlugin.groovy
@@ -31,6 +31,13 @@ class FatLibraryPlugin implements Plugin<Project> {
         createConfiguration(embedConf)
         print("Creating configuration embed\n")
 
+        project.android.buildTypes.all { buildType ->
+            String configName = buildType.name + 'Embed'
+            Configuration configuration = project.configurations.create(configName)
+            createConfiguration(configuration)
+            print("Creating configuration " + configName + "\n")
+        }
+
         project.android.productFlavors.all { flavor ->
             String configName = flavor.name + 'Embed'
             Configuration configuration = project.configurations.create(configName)
@@ -51,6 +58,9 @@ class FatLibraryPlugin implements Plugin<Project> {
             project.android.libraryVariants.all { variant ->
 //                String configName = variant.name + 'Embed'
 
+                String buildTypeConfigName = variant.getBuildType().name + 'Embed'
+                Configuration buildTypeConfiguration = project.configurations.getByName(buildTypeConfigName)
+
                 /**
                  * Doesn't support more than one flavor dimension: LibraryVariant does not have
                  * public interface for VariantConfiguration list(which holds flavor configs).
@@ -61,10 +71,12 @@ class FatLibraryPlugin implements Plugin<Project> {
 
                 Set<ResolvedArtifact> artifacts = new HashSet<>()
                 artifacts.addAll(commonArtifacts)
+                artifacts.addAll(resolveArtifacts(buildTypeConfiguration))
                 artifacts.addAll(resolveArtifacts(flavorConfiguration))
 
                 Set<ResolvedDependency> unResolveArtifacts = new HashSet<>()
                 unResolveArtifacts.addAll(commonUnResolveArtifacts)
+                unResolveArtifacts.addAll(dealUnResolveArtifacts(buildTypeConfiguration, artifacts))
                 unResolveArtifacts.addAll(dealUnResolveArtifacts(flavorConfiguration, artifacts))
 
                 processVariant(variant, artifacts, unResolveArtifacts)

--- a/source/src/main/groovy/com/kezong/fataar/FatLibraryPlugin.groovy
+++ b/source/src/main/groovy/com/kezong/fataar/FatLibraryPlugin.groovy
@@ -5,8 +5,6 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.ProjectConfigurationException
 import org.gradle.api.artifacts.Configuration
-import org.gradle.api.artifacts.DependencyResolutionListener
-import org.gradle.api.artifacts.ResolvableDependencies
 import org.gradle.api.artifacts.ResolvedArtifact
 import org.gradle.api.artifacts.ResolvedDependency
 
@@ -24,23 +22,52 @@ class FatLibraryPlugin implements Plugin<Project> {
 
     private Project project
 
-    private Configuration embedConf
-
-    private Set<ResolvedArtifact> artifacts
-
-    private Set<ResolvedDependency> unResolveArtifact
-
     @Override
     void apply(Project project) {
         this.project = project
         Utils.setProject(project)
         checkAndroidPlugin()
-        createConfiguration()
+        final Configuration embedConf = project.configurations.create('embed')
+        createConfiguration(embedConf)
+        print("Creating configuration embed\n")
+
+        project.android.productFlavors.all { flavor ->
+            String configName = flavor.name + 'Embed'
+            Configuration configuration = project.configurations.create(configName)
+            createConfiguration(configuration)
+            print("Creating configuration " + configName + "\n")
+        }
+
+//        project.android.libraryVariants.all { variant ->
+//            String configName = variant.name + 'Embed'
+//            final Configuration configuration = project.configurations.create(configName)
+//            createConfiguration(configuration)
+//            print("Configuration created: " + configName + "\n")
+//        }
+
         project.afterEvaluate {
-            resolveArtifacts()
-            dealUnResolveArtifacts()
+            Set<ResolvedArtifact> commonArtifacts = resolveArtifacts(embedConf)
+            Set<ResolvedDependency> commonUnResolveArtifacts = dealUnResolveArtifacts(embedConf, commonArtifacts)
             project.android.libraryVariants.all { variant ->
-                processVariant(variant)
+//                String configName = variant.name + 'Embed'
+
+                /**
+                 * Doesn't support more than one flavor dimension: LibraryVariant does not have
+                 * public interface for VariantConfiguration list(which holds flavor configs).
+                 * Also Library plugin doesn't have API for variants in the project.
+                 */
+                String flavorConfigName = variant.getFlavorName() + 'Embed'
+                Configuration flavorConfiguration = project.configurations.getByName(flavorConfigName)
+
+                Set<ResolvedArtifact> artifacts = new HashSet<>()
+                artifacts.addAll(commonArtifacts)
+                artifacts.addAll(resolveArtifacts(flavorConfiguration))
+
+                Set<ResolvedDependency> unResolveArtifacts = new HashSet<>()
+                unResolveArtifacts.addAll(commonUnResolveArtifacts)
+                unResolveArtifacts.addAll(dealUnResolveArtifacts(flavorConfiguration, artifacts))
+
+                processVariant(variant, artifacts, unResolveArtifacts)
             }
         }
 
@@ -53,29 +80,15 @@ class FatLibraryPlugin implements Plugin<Project> {
         }
     }
 
-    private void createConfiguration() {
-        embedConf = project.configurations.create('embed')
+    private void createConfiguration(Configuration embedConf) {
         embedConf.visible = false
         embedConf.transitive = false
-
-        project.gradle.addListener(new DependencyResolutionListener() {
-            @Override
-            void beforeResolve(ResolvableDependencies resolvableDependencies) {
-                embedConf.dependencies.each { dependency ->
-                    project.dependencies.add('compileOnly', dependency)
-                }
-                project.gradle.removeListener(this)
-            }
-
-            @Override
-            void afterResolve(ResolvableDependencies resolvableDependencies) {
-            }
-        })
+        project.gradle.addListener(new ConfigurationDependencyResolutionListener(project, embedConf))
     }
 
-    private void resolveArtifacts() {
+    private Set<ResolvedArtifact> resolveArtifacts(Configuration configuration) {
         def set = new HashSet<>()
-        embedConf.resolvedConfiguration.resolvedArtifacts.each { artifact ->
+        configuration.resolvedConfiguration.resolvedArtifacts.each { artifact ->
             // jar file wouldn't be here
             if (ARTIFACT_TYPE_AAR == artifact.type || ARTIFACT_TYPE_JAR == artifact.type) {
                 Utils.logAnytime('[embed detected][' + artifact.type + ']' + artifact.moduleVersion.id)
@@ -84,18 +97,18 @@ class FatLibraryPlugin implements Plugin<Project> {
             }
             set.add(artifact)
         }
-        artifacts = Collections.unmodifiableSet(set)
+        return Collections.unmodifiableSet(set)
     }
 
-    private void processVariant(LibraryVariant variant) {
+    private void processVariant(LibraryVariant variant, Set<ResolvedArtifact> artifacts, Set<ResolvedDependency> unResolveArtifacts) {
         def processor = new VariantProcessor(project, variant)
         processor.addArtifacts(artifacts)
-        processor.addUnResolveArtifact(unResolveArtifact)
+        processor.addUnResolveArtifact(unResolveArtifacts)
         processor.processVariant()
     }
 
-    private void dealUnResolveArtifacts() {
-        def dependencies = Collections.unmodifiableSet(embedConf.resolvedConfiguration.firstLevelModuleDependencies)
+    private Set<ResolvedDependency> dealUnResolveArtifacts(Configuration configuration, Set<ResolvedArtifact> artifacts) {
+        def dependencies = Collections.unmodifiableSet(configuration.resolvedConfiguration.firstLevelModuleDependencies)
         def dependencySet = new HashSet()
         dependencies.each { dependency ->
             boolean match = false
@@ -109,6 +122,6 @@ class FatLibraryPlugin implements Plugin<Project> {
                 dependencySet.add(dependency)
             }
         }
-        unResolveArtifact = Collections.unmodifiableSet(dependencySet)
+        return Collections.unmodifiableSet(dependencySet)
     }
 }


### PR DESCRIPTION
Added support for specific build type and product flavor dependencies. Unfortunately, due to limitations of Android Library gradle plugin it is limited to a single flavor dimension. It will ignore flavor dependencies if there are multiple dimensions but default 'embed' and buildtype dependencies will still work. In any case, default 'embed' configuration is still available and working. 

Example build type usage:
`releaseEmbed project(path: ':lib-aar', configuration: 'default')`

Example product flavor usage:
`flavorNameEmbed project(path: ':lib-aar', configuration: 'default')`