### PR TITLE
Full variant name support

### DIFF
--- a/source/src/main/groovy/com/kezong/fataar/FatLibraryPlugin.groovy
+++ b/source/src/main/groovy/com/kezong/fataar/FatLibraryPlugin.groovy
@@ -63,6 +63,7 @@ class FatLibraryPlugin implements Plugin<Project> {
                 try {
                     buildTypeConfiguration = project.configurations.getByName(buildTypeConfigName)
                 } catch(Exception ignored) {
+                    print("Ignored configuration " + buildTypeConfigName + "\n")
                 }
 
                 /**
@@ -76,6 +77,7 @@ class FatLibraryPlugin implements Plugin<Project> {
                     try {
                         flavorConfiguration = project.configurations.getByName(flavorConfigName)
                     } catch(Exception ignored) {
+                        print("Ignored configuration " + flavorConfigName + "\n")
                     }
                 }
 
@@ -83,8 +85,9 @@ class FatLibraryPlugin implements Plugin<Project> {
                 Configuration variantConfiguration
                 if (variantConfigName != buildTypeConfigName) {
                     try {
-                        flavorConfiguration = project.configurations.getByName(variantConfigName)
+                        variantConfiguration = project.configurations.getByName(variantConfigName)
                     } catch(Exception ignored) {
+                        print("Ignored configuration " + variantConfigName + "\n")
                     }
                 }
 


### PR DESCRIPTION
Added embed support for full library variant names with combined flavor and build type names.

Example variant usage:
flavorNameReleaseEmbed project(path: ':lib-aar', configuration: 'default')