### PR TITLE
Include styleable attributes from R-def file

### DIFF
--- a/source/src/main/groovy/com/kezong/fataar/RProcessor.groovy
+++ b/source/src/main/groovy/com/kezong/fataar/RProcessor.groovy
@@ -148,6 +148,10 @@ class RProcessor {
                 }
                 def subclass = splits.get(0)
                 def name = splits.get(1)
+                if (subclass == "attr?"){
+                    //styleable attributes
+                    subclass = "attr"
+                }
                 map[subclass].putAt(name, 1)
                 if (subclass == "styleable" && splits.size() > 2) {
                     for (int i = 2; i < splits.size(); ++i) {


### PR DESCRIPTION
Gradle plugin version: 3.6.2

Attributes which are declared as stylable are treated as "maybe attributes", or "attr?" in the R-def.txt. Our build which depend on a library which has stylable attributes fail because of this.

For example, the following attribute

```
<resources>

    <declare-styleable name="My.Theme">
          <attr name="myAttribute" format="reference" />
     </declare-styleable>
````

Will be declared as folllowing in the R-def.txt

```
attr? myAttribute
```

With this fix, stylable attributes will be kept in the generated R.class for the library. 
