### PR TITLE
Fix manifest merging task to work with AGP 4.0.0

### DIFF
--- a/source/build.gradle
+++ b/source/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     implementation gradleApi()
     implementation localGroovy()
 
-    implementation 'com.android.tools.build:gradle:3.4.1'
+    implementation 'com.android.tools.build:gradle:4.0.0'
 }
 
 //afterEvaluate {

--- a/source/src/main/groovy/com/kezong/fataar/VariantProcessor.groovy
+++ b/source/src/main/groovy/com/kezong/fataar/VariantProcessor.groovy
@@ -159,7 +159,7 @@ class VariantProcessor {
      */
     private void processManifest() {
         Task processManifestTask = mVersionAdapter.getProcessManifest()
-        String manifestInputDir ="${mProject.getBuildDir()}/intermediates/fat-R/manifest"
+        String manifestInputDir = "${mProject.getBuildDir()}/intermediates/fat-R/manifest"
         File manifestOutput
         if (mGradlePluginVersion != null && Utils.compareVersion(mGradlePluginVersion, "3.3.0") >= 0) {
             manifestOutput = mProject.file("${mProject.buildDir.path}/intermediates/library_manifest/${mVariant.name}/AndroidManifest.xml")


### PR DESCRIPTION
AGP 4.0.0 brings in a change which wipes out the output files whenever a task gets rerun
See https://android.googlesource.com/platform/tools/base/+/studio-master-dev/build-system/gradle-core/src/main/java/com/android/build/gradle/internal/tasks/NonIncrementalTask.kt
The manifest merging task tries to update the manifest in place, by setting input == output, resulting in the input file being explicitly deleted just before the task gets run
Fix by making input != output, by setting input to some arbitrary copy location in the fat-R directory