### PR TITLE
Make sure embed dependencies are available for tests

### DIFF
--- a/source/src/main/groovy/com/kezong/fataar/ConfigurationDependencyResolutionListener.groovy
+++ b/source/src/main/groovy/com/kezong/fataar/ConfigurationDependencyResolutionListener.groovy
@@ -28,8 +28,10 @@ class ConfigurationDependencyResolutionListener implements DependencyResolutionL
                 DefaultProjectDependency dependencyClone = dependency.copy()
                 dependencyClone.targetConfiguration = null;
                 project.dependencies.add('compileOnly', dependencyClone)
+                project.dependencies.add('testCompile', dependencyClone)
             } else {
                 project.dependencies.add('compileOnly', dependency)
+                project.dependencies.add('testCompile', dependency)
             }
         }
         project.gradle.removeListener(this)


### PR DESCRIPTION
compileOnly is apparently not available for tests.

There might be a better way to solve this.