### PR TITLE
Use Gradle's configuration avoidance APIs

### DIFF
--- a/source/src/main/groovy/com/kezong/fataar/RProcessor.groovy
+++ b/source/src/main/groovy/com/kezong/fataar/RProcessor.groovy
@@ -197,7 +197,7 @@ class RProcessor {
             it.sourceCompatibility = mProject.android.compileOptions.sourceCompatibility
             it.targetCompatibility = mProject.android.compileOptions.targetCompatibility
             it.classpath = classpath
-            it.destinationDir destinationDir
+            it.destinationDir = destinationDir
         })
 
         task.doFirst {
@@ -214,7 +214,7 @@ class RProcessor {
         return task
     }
 
-    private Task createRJarTask(final def fromDir, final def desFile) {
+    private Task createRJarTask(final File fromDir, final File desFile) {
         String taskName = "createRsJar${mVariant.name.capitalize()}"
         Task task = mProject.getTasks().create(taskName, Jar.class, {
             it.from fromDir.path
@@ -225,7 +225,7 @@ class RProcessor {
                 it.getDestinationDirectory().set(desFile)
             } else {
                 it.archiveName = "r-classes.jar"
-                it.destinationDir desFile
+                it.destinationDir = desFile
             }
         })
         task.doFirst {
@@ -244,14 +244,14 @@ class RProcessor {
                 it.getDestinationDirectory().set(destDir)
             } else {
                 it.archiveName = new File(filePath).name
-                it.destinationDir(destDir)
+                it.destinationDir = destDir
             }
         })
 
         return task
     }
 
-    def deleteEmptyDir = { file ->
+    private void deleteEmptyDir(final File file) {
         file.listFiles().each { x ->
             if (x.isDirectory()) {
                 if (x.listFiles().size() == 0) {

--- a/source/src/main/groovy/com/kezong/fataar/VariantProcessor.groovy
+++ b/source/src/main/groovy/com/kezong/fataar/VariantProcessor.groovy
@@ -297,24 +297,24 @@ class VariantProcessor {
      */
     private void processResourcesAndR() {
         String taskPath = 'generate' + mVariant.name.capitalize() + 'Resources'
-        Task resourceGenTask = mProject.tasks.findByPath(taskPath)
+        TaskProvider resourceGenTask = mProject.tasks.named(taskPath)
         if (resourceGenTask == null) {
             throw new RuntimeException("Can not find task ${taskPath}!")
         }
 
-        resourceGenTask.doFirst {
-            for (archiveLibrary in mAndroidArchiveLibraries) {
-                mProject.android.sourceSets.each {
-                    if (it.name == mVariant.name) {
-                        Utils.logInfo("Merge resource，Library res：${archiveLibrary.resFolder}")
-                        it.res.srcDir(archiveLibrary.resFolder)
+        resourceGenTask.configure {
+            dependsOn(mExplodeTasks)
+
+            doFirst {
+                for (archiveLibrary in mAndroidArchiveLibraries) {
+                    mProject.android.sourceSets.each {
+                        if (it.name == mVariant.name) {
+                            Utils.logInfo("Merge resource，Library res：${archiveLibrary.resFolder}")
+                            it.res.srcDir(archiveLibrary.resFolder)
+                        }
                     }
                 }
             }
-        }
-
-        mExplodeTasks.each { it ->
-            resourceGenTask.dependsOn(it)
         }
     }
 

--- a/source/src/main/groovy/com/kezong/fataar/VariantProcessor.groovy
+++ b/source/src/main/groovy/com/kezong/fataar/VariantProcessor.groovy
@@ -89,7 +89,7 @@ class VariantProcessor {
 
     void processVariant() {
         String taskPath = 'pre' + mVariant.name.capitalize() + 'Build'
-        Task prepareTask = mProject.tasks.findByPath(taskPath)
+        TaskProvider prepareTask = mProject.tasks.named(taskPath)
         if (prepareTask == null) {
             throw new RuntimeException("Can not find task ${taskPath}!")
         }
@@ -127,7 +127,7 @@ class VariantProcessor {
     /**
      * exploded artifact files
      */
-    private void processArtifacts(Task prepareTask, Task bundleTask) {
+    private void processArtifacts(TaskProvider prepareTask, Task bundleTask) {
         for (final ResolvedArtifact artifact in mResolvedArtifacts) {
             if (FatLibraryPlugin.ARTIFACT_TYPE_JAR == artifact.type) {
                 addJarFile(artifact.file)
@@ -377,7 +377,7 @@ class VariantProcessor {
      * fixme
      * merge proguard.txt
      */
-    private void processProguardTxt(Task prepareTask) {
+    private void processProguardTxt(TaskProvider prepareTask) {
         String taskPath = 'merge' + mVariant.name.capitalize() + 'ConsumerProguardFiles'
         TaskProvider mergeFileTask = mProject.tasks.named(taskPath)
         if (mergeFileTask == null) {

--- a/source/src/main/groovy/com/kezong/fataar/VariantProcessor.groovy
+++ b/source/src/main/groovy/com/kezong/fataar/VariantProcessor.groovy
@@ -23,7 +23,7 @@ class VariantProcessor {
 
     private final LibraryVariant mVariant
 
-    private Set<ResolvedArtifact> mResolvedArtifacts = new ArrayList<>()
+    private Set<ResolvedArtifact> mResolvedArtifacts = new HashSet<>()
 
     private Collection<AndroidArchiveLibrary> mAndroidArchiveLibraries = new ArrayList<>()
 

--- a/source/src/main/groovy/com/kezong/fataar/VariantProcessor.groovy
+++ b/source/src/main/groovy/com/kezong/fataar/VariantProcessor.groovy
@@ -239,7 +239,7 @@ class VariantProcessor {
         return task
     }
 
-    private TaskProvider handleJarMergeTask(final Task syncLibTask) {
+    private TaskProvider handleJarMergeTask(final TaskProvider syncLibTask) {
         final TaskProvider task = mProject.tasks.register('mergeJars' + mVariant.name.capitalize()) {
             dependsOn(mExplodeTasks)
             dependsOn(mVersionAdapter.getJavaCompileTask())
@@ -270,13 +270,15 @@ class VariantProcessor {
         }
 
         String taskPath = mVersionAdapter.getSyncLibJarsTaskPath()
-        Task syncLibTask = mProject.tasks.findByPath(taskPath)
+        TaskProvider syncLibTask = mProject.tasks.named(taskPath)
         if (syncLibTask == null) {
             throw new RuntimeException("Can not find task ${taskPath}!")
         }
 
         TaskProvider mergeClasses = handleClassesMergeTask(isMinifyEnabled)
-        syncLibTask.dependsOn(mergeClasses)
+        syncLibTask.configure {
+            dependsOn(mergeClasses)
+        }
 
         if (!isMinifyEnabled) {
             TaskProvider mergeJars = handleJarMergeTask(syncLibTask)


### PR DESCRIPTION
Replaced eager APIs with [Gradle's configuration avoidance APIs](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html) wherever possible to reduce the number of tasks created and configured during **configuration phase**.

There's still plenty of room for improvement but managed to reduce the number of created tasks for the sample project from 231 to 177.

This is **before** with 231  tasks and plenty of them created immediately
<img width="1339" alt="Screen Shot 2020-09-08 at 21 47 36" src="https://user-images.githubusercontent.com/8038503/92521332-5dce5c80-f21d-11ea-8f53-2409bfd11fc9.png">


and this is **after**
<img width="1335" alt="Screen Shot 2020-09-08 at 21 49 06" src="https://user-images.githubusercontent.com/8038503/92521475-92421880-f21d-11ea-9523-83d2c04f5a0f.png">


Also, this APIs require **Gradle 4.9** or later, but since it's more than 2 years old now I figured it wouldn't be much of a problem.