### PR TITLE
Fixes for Gradle 6.8 changes

### DIFF
--- a/source/build.gradle
+++ b/source/build.gradle
@@ -1,35 +1,3 @@
-ext {
-    isCi = 'true' == System.getenv('CI')
-    ciBuildNumber = System.getenv('BUILD_NUM')
-
-    workingBranch = {
-        'git rev-parse --abbrev-ref HEAD'.execute([], rootDir).text.trim()
-    }
-
-    shortSha = {
-        'git rev-parse --short HEAD'.execute([], rootDir).text.trim()
-    }
-
-    isDirty = {
-        'git describe --dirty'.execute([], rootDir).text.trim().contains('dirty')
-    }
-
-    isReleaseBuild = {
-        workingBranch().equals('master') && !isDirty()
-    }
-
-    versionName = {
-        def version = '1.2.19'.concat("-${shortSha()}")
-        version = isReleaseBuild() ?
-                version :
-                version.concat(".${workingBranch().replace('/', '.')}".replace('.HEAD', ''))
-        if (ciBuildNumber != null) {
-            version = version.concat(".${ciBuildNumber}")
-        }
-        return version
-    }
-}
-
 apply plugin: 'groovy'
 apply plugin: 'com.novoda.bintray-release'
 

--- a/source/build.gradle
+++ b/source/build.gradle
@@ -1,3 +1,35 @@
+ext {
+    isCi = 'true' == System.getenv('CI')
+    ciBuildNumber = System.getenv('BUILD_NUM')
+
+    workingBranch = {
+        'git rev-parse --abbrev-ref HEAD'.execute([], rootDir).text.trim()
+    }
+
+    shortSha = {
+        'git rev-parse --short HEAD'.execute([], rootDir).text.trim()
+    }
+
+    isDirty = {
+        'git describe --dirty'.execute([], rootDir).text.trim().contains('dirty')
+    }
+
+    isReleaseBuild = {
+        workingBranch().equals('master') && !isDirty()
+    }
+
+    versionName = {
+        def version = '1.2.19'.concat("-${shortSha()}")
+        version = isReleaseBuild() ?
+                version :
+                version.concat(".${workingBranch().replace('/', '.')}".replace('.HEAD', ''))
+        if (ciBuildNumber != null) {
+            version = version.concat(".${ciBuildNumber}")
+        }
+        return version
+    }
+}
+
 apply plugin: 'groovy'
 apply plugin: 'com.novoda.bintray-release'
 


### PR DESCRIPTION
**Background**
Gradle 6.8 has changed some internal details with resolvable artifacts causing build breakages. In this PR, I address these issues.

**Changes**
* `DefaultResolvedArtifact` has been renamed to `DefaultResolvableArtifact`. I added a check to instantiate proper class as necessary.
* Variant artifacts can now be instances of `PreResolvedResolvableArtifact` which breaks task dependency container fetching logic. I updated it to handle this properly.

**Test Plan**
 I published this to maven local and tested against an internal project and it correctly worked.
