### PR TITLE
Issue-333: Android Gradle plugin 7.0.0 support

### DIFF
--- a/example/app/build.gradle
+++ b/example/app/build.gradle
@@ -31,8 +31,8 @@ android {
         }
     }
 
-    dataBinding {
-        enabled = true
+    buildFeatures {
+        dataBinding = true
     }
 
     kotlinOptions {

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.0'
+        classpath 'com.android.tools.build:gradle:7.0.0'
         classpath 'com.github.kezong:fat-aar:1.3.6'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.72"
     }

--- a/example/gradle.properties
+++ b/example/gradle.properties
@@ -1,3 +1,2 @@
-android.databinding.enableV2=true
 android.useAndroidX=true
 android.enableJetifier=true

--- a/example/gradle/wrapper/gradle-wrapper.properties
+++ b/example/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip

--- a/example/lib-aar/build.gradle
+++ b/example/lib-aar/build.gradle
@@ -20,8 +20,8 @@ android {
         }
     }
 
-    dataBinding {
-        enabled = true
+    buildFeatures {
+        dataBinding = true
     }
 
     flavorDimensions "default"

--- a/example/lib-aar2/build.gradle
+++ b/example/lib-aar2/build.gradle
@@ -17,8 +17,8 @@ android {
         }
     }
 
-    dataBinding {
-        enabled = true
+    buildFeatures {
+        dataBinding = true
     }
 
     flavorDimensions "default2"

--- a/source/build.gradle
+++ b/source/build.gradle
@@ -18,5 +18,6 @@ dependencies {
     implementation gradleApi()
     implementation localGroovy()
     implementation "org.javassist:javassist:3.27.0-GA"
-    implementation 'com.android.tools.build:gradle:4.2.0'
+    implementation 'com.android.tools.build:gradle:7.0.0'
+    implementation 'com.android.tools:common:30.0.0'
 }

--- a/source/gradle/wrapper/gradle-wrapper.properties
+++ b/source/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip

--- a/source/src/main/groovy/com/kezong/fataar/FatAarPlugin.groovy
+++ b/source/src/main/groovy/com/kezong/fataar/FatAarPlugin.groovy
@@ -54,7 +54,7 @@ class FatAarPlugin implements Plugin<Project> {
             }
         }
 
-        project.android.libraryVariants.all { LibraryVariant variant ->
+        project.android.libraryVariants.all { variant ->
             Collection<ResolvedArtifact> artifacts = new ArrayList()
             Collection<ResolvedDependency> firstLevelDependencies = new ArrayList<>()
             embedConfigurations.each { configuration ->
@@ -64,7 +64,7 @@ class FatAarPlugin implements Plugin<Project> {
                         || configuration.name == variant.name + CONFIG_SUFFIX) {
                     Collection<ResolvedArtifact> resolvedArtifacts = resolveArtifacts(configuration)
                     artifacts.addAll(resolvedArtifacts)
-                    artifacts.addAll(dealUnResolveArtifacts(configuration, variant, resolvedArtifacts))
+                    artifacts.addAll(dealUnResolveArtifacts(configuration, variant as LibraryVariant, resolvedArtifacts))
                     firstLevelDependencies.addAll(configuration.resolvedConfiguration.firstLevelModuleDependencies)
                 }
             }

--- a/source/src/main/groovy/com/kezong/fataar/VariantProcessor.groovy
+++ b/source/src/main/groovy/com/kezong/fataar/VariantProcessor.groovy
@@ -191,7 +191,7 @@ class VariantProcessor {
     }
 
     private void transformRClasses(RClassesTransform transform, TaskProvider transformTask, TaskProvider bundleTask, TaskProvider reBundleTask) {
-        transform.putTargetPackage(mVariant.name, mVariant.getApplicationId())
+        transform.putTargetPackage(mVariant.name, mVariant.applicationIdTextResource.asString())
         transformTask.configure {
                     doFirst {
                         // library package name parsed by aar's AndroidManifest.xml

--- a/source/upload.gradle
+++ b/source/upload.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'maven-publish'
-apply plugin: 'maven'
 apply plugin: 'java'
 apply plugin: 'signing'
 


### PR DESCRIPTION
Added support for AGP 7.0, fix for https://github.com/kezong/fat-aar-android/issues/333. 

Tested changes with AGP 3.0+ and Gradle 7.0+. Probably, needs more testing with different old versions AGP and Gradle.
Currently, AGP 7.0 limited with usage of Java 11 and Gradle 7.0 respectively.