### PR TITLE
use default flavor if there is no product flavor

### DIFF
--- a/source/src/main/groovy/com/kezong/fataar/FlavorArtifact.groovy
+++ b/source/src/main/groovy/com/kezong/fataar/FlavorArtifact.groovy
@@ -152,11 +152,8 @@ class FlavorArtifact {
                 }
             }
 
-            if (variant.productFlavors.isEmpty()) {
-                return false
-            }
             // 2. find missingStrategies
-            ProductFlavor flavor = variant.productFlavors.first()
+            ProductFlavor flavor = variant.productFlavors.isEmpty() ? variant.mergedFlavor : variant.productFlavors.first()
             flavor.missingDimensionStrategies.find { entry ->
                 String toDimension = entry.getKey()
                 String toFlavor = entry.getValue().getFallbacks().first()


### PR DESCRIPTION
This change uses the `mergedFlavor` if there are no `productFlavors`. This allows to use `missingDimensionStrategy` in the `defaultConfig`. 

fixed #343