### PR TITLE
Fix issue with modules of the same name

### DIFF
--- a/source/src/main/groovy/com/kezong/fataar/FlavorArtifact.groovy
+++ b/source/src/main/groovy/com/kezong/fataar/FlavorArtifact.groovy
@@ -122,7 +122,7 @@ class FlavorArtifact {
 
     private static Project getArtifactProject(Project project, ResolvedDependency unResolvedArtifact) {
         for (Project p : project.getRootProject().getAllprojects()) {
-            if (unResolvedArtifact.moduleName == p.name) {
+            if (unResolvedArtifact.moduleName == p.name && unResolvedArtifact.moduleGroup == p.group) {
                 return p
             }
         }


### PR DESCRIPTION
Ran into an issue with two modules having the same 'name' but living in different folders. For example, if I have a module named `:bar` and embed one that's `:foo:bar`. It would match on just `bar` and cause a circular dependency on a bundle task. Checking for both name and group appears to resolve the issue.

I'm not sure what the process is for contributions - if there are specific checks I should run through first, let me know.