### PR TITLE
Format <declare-styleable/>

### DIFF
--- a/example/gradle.properties
+++ b/example/gradle.properties
@@ -1,2 +1,3 @@
 android.useAndroidX=true
 android.enableJetifier=true
+android.disableResourceValidation=true

--- a/example/lib-aar/src/main/res/values/attrs.xml
+++ b/example/lib-aar/src/main/res/values/attrs.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <declare-styleable name="DeclareStyleableDefault">
+    <attr format="color" name="exampleTextColor"/>
+    <attr format="color" name="exampleBackground"/>
+  </declare-styleable>
+</resources>

--- a/example/lib-aar2/src/main/res/values/attrs.xml
+++ b/example/lib-aar2/src/main/res/values/attrs.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <declare-styleable name="DeclareStyleableNew">
+    <attr format="color" name="exampleTextColor"/>
+    <attr format="color" name="exampleTintTitle"/>
+  </declare-styleable>
+</resources>

--- a/example/lib-main/build.gradle
+++ b/example/lib-main/build.gradle
@@ -71,6 +71,8 @@ fataar {
      * @since 1.3.0
      */
     transitive = true
+
+    formatDeclareStyleable = true
 }
 
 dependencies {

--- a/source/build.gradle
+++ b/source/build.gradle
@@ -1,5 +1,5 @@
 apply plugin: 'groovy'
-apply from: "./upload.gradle"
+//apply from: "./upload.gradle"
 
 buildscript {
     repositories {
@@ -19,4 +19,5 @@ dependencies {
     implementation localGroovy()
     implementation "org.javassist:javassist:3.27.0-GA"
     implementation 'com.android.tools.build:gradle:4.2.0'
+    implementation "org.dom4j:dom4j:2.1.3"
 }

--- a/source/src/main/groovy/com/kezong/fataar/FatAarExtension.groovy
+++ b/source/src/main/groovy/com/kezong/fataar/FatAarExtension.groovy
@@ -25,4 +25,6 @@ class FatAarExtension {
      * @since 1.3.0
      */
     boolean transitive = false
+
+    boolean formatDeclareStyleable = false
 }

--- a/source/src/main/groovy/com/kezong/fataar/FatAarPlugin.groovy
+++ b/source/src/main/groovy/com/kezong/fataar/FatAarPlugin.groovy
@@ -39,6 +39,7 @@ class FatAarPlugin implements Plugin<Project> {
         project.afterEvaluate {
             doAfterEvaluate()
         }
+        ValuesHelper.getInstance().init(project)
     }
 
     private registerTransform() {

--- a/source/src/main/groovy/com/kezong/fataar/FatAarPlugin.groovy
+++ b/source/src/main/groovy/com/kezong/fataar/FatAarPlugin.groovy
@@ -39,7 +39,7 @@ class FatAarPlugin implements Plugin<Project> {
         project.afterEvaluate {
             doAfterEvaluate()
         }
-        ValuesHelper.getInstance().init(project)
+        ValuesHelper.attach(project)
     }
 
     private registerTransform() {

--- a/source/src/main/groovy/com/kezong/fataar/VariantProcessor.groovy
+++ b/source/src/main/groovy/com/kezong/fataar/VariantProcessor.groovy
@@ -169,6 +169,13 @@ class VariantProcessor {
                 it.destinationDir = aarOutputFile.getParentFile()
             }
 
+            if (mProject.fataar.formatDeclareStyleable) {
+                doFirst {
+                    FatUtils.logAnytime("Extension formatDeclareStyleable enable!")
+                    ValuesHelper.getInstance().splitValuesXmlRepeatAttr(reBundleDir)
+                }
+            }
+
             doLast {
                 FatUtils.logAnytime(" target: ${aarOutputFile.absolutePath} [${FatUtils.formatDataSize(aarOutputFile.size())}]")
             }

--- a/source/src/main/groovy/com/kezong/fataar/VariantProcessor.groovy
+++ b/source/src/main/groovy/com/kezong/fataar/VariantProcessor.groovy
@@ -172,7 +172,7 @@ class VariantProcessor {
             if (mProject.fataar.formatDeclareStyleable) {
                 doFirst {
                     FatUtils.logAnytime("Extension formatDeclareStyleable enable!")
-                    ValuesHelper.getInstance().splitValuesXmlRepeatAttr(reBundleDir)
+                    ValuesHelper.splitValuesXmlRepeatAttr(reBundleDir)
                 }
             }
 

--- a/source/src/main/java/com/kezong/fataar/StyleAttr.java
+++ b/source/src/main/java/com/kezong/fataar/StyleAttr.java
@@ -1,0 +1,28 @@
+package com.kezong.fataar;
+
+public class StyleAttr {
+    public StyleAttr(String name_, String format_) {
+        name = name_;
+        format = format_;
+    }
+
+    public static final String ATTR_NAME = "name";
+    public static final String ATTR_FORMAT = "format";
+    public String name = "";
+    public String format = "";
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        StyleAttr styleAttr = (StyleAttr) o;
+        return name.equals(styleAttr.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return name.hashCode();
+    }
+
+}

--- a/source/src/main/java/com/kezong/fataar/ValuesHelper.java
+++ b/source/src/main/java/com/kezong/fataar/ValuesHelper.java
@@ -1,0 +1,111 @@
+package com.kezong.fataar;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.dom4j.Attribute;
+import org.dom4j.Document;
+import org.dom4j.Element;
+import org.dom4j.io.SAXReader;
+import org.dom4j.io.XMLWriter;
+import org.gradle.api.Project;
+
+
+public class ValuesHelper {
+    private static ValuesHelper sInstance = null;
+    private Project mProject;
+    private static final String ELE_ATTR = "attr";
+    private static final String ELE_DECLARE_STYLEABLE = "declare-styleable";
+
+    public static ValuesHelper getInstance() {
+        if (sInstance == null) {
+            sInstance = new ValuesHelper();
+        }
+        return sInstance;
+    }
+
+    public void init(Project project) {
+        // fix: org.xml.sax.SAXNotRecognizedException: unrecognized feature http://xml.org/sax/features/external-general-entities
+        System.setProperty("javax.xml.parsers.SAXParserFactory",
+                "com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl");
+        mProject = project;
+    }
+
+    public void splitValuesXmlRepeatAttr(File pkgFile) {
+
+        final File valueXml = new File(pkgFile, "res/values/values.xml");
+        if (!valueXml.exists()) {
+            mProject.getLogger().info("ValuesHelper: value xml doesn't exist...");
+            return;
+        }
+        try {
+            formatRepeatAttr(valueXml);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private void formatRepeatAttr(final File file) {
+        try {
+            mProject.getLogger()
+                    .info("ValuesHelper: deleteDuplicateAttr : " + file.getAbsolutePath());
+
+            SAXReader xmlReader = new SAXReader();
+
+            Document doc = xmlReader.read(file);
+
+            final Element rootEle = doc.getRootElement();
+
+            if (rootEle == null) {
+                return;
+            }
+
+            List<Element> styleableElements = rootEle.elements(ELE_DECLARE_STYLEABLE);
+
+            final Set<StyleAttr> repeatStyleAttr = new HashSet<>();
+            final Set<StyleAttr> styleAttrs = new HashSet<>();
+
+            // 只保留第一个attr的定义
+            for (Element declareStyle : styleableElements) {
+                List<Element> attrs = declareStyle.elements(ELE_ATTR);
+                for (Element attr : attrs) {
+                    StyleAttr styleAttr = getStyleAttr(attr);
+                    if (styleAttr != null) {
+                        if (styleAttrs.contains(styleAttr)) {
+                            repeatStyleAttr.add(styleAttr);
+                        } else {
+                            styleAttrs.add(styleAttr);
+                        }
+                        if (repeatStyleAttr.contains(styleAttr)) {
+                            Attribute format = attr.attribute(StyleAttr.ATTR_FORMAT);
+                            attr.remove(format);
+                        }
+                    }
+                }
+            }
+
+
+            XMLWriter writer = new XMLWriter(new FileOutputStream(file));
+            writer.write(doc);
+            writer.close();
+
+        } catch (Exception e) {
+            mProject.getLogger()
+                    .info("ValuesHelper: exclude repeat attr failed : " + e.getMessage());
+            e.printStackTrace();
+        }
+
+    }
+
+    private static StyleAttr getStyleAttr(Element element) {
+        Attribute name = element.attribute(StyleAttr.ATTR_NAME);
+        Attribute format = element.attribute(StyleAttr.ATTR_FORMAT);
+        if (name != null && format != null) {
+            return new StyleAttr(name.getValue(), format.getValue());
+        }
+        return null;
+    }
+}

--- a/source/src/main/java/com/kezong/fataar/ValuesHelper.java
+++ b/source/src/main/java/com/kezong/fataar/ValuesHelper.java
@@ -55,11 +55,27 @@ public class ValuesHelper {
             if (rootEle == null) {
                 return;
             }
-
+            List<Element> rootAttr = rootEle.elements(ELE_ATTR);
             List<Element> styleableElements = rootEle.elements(ELE_DECLARE_STYLEABLE);
 
             final Set<StyleAttr> repeatStyleAttr = new HashSet<>();
             final Set<StyleAttr> styleAttrs = new HashSet<>();
+
+            //先查找根节点<attr
+            for (Element attr : rootAttr) {
+                StyleAttr styleAttr = getStyleAttr(attr);
+                if (styleAttr != null) {
+                    if (styleAttrs.contains(styleAttr)) {
+                        repeatStyleAttr.add(styleAttr);
+                    } else {
+                        styleAttrs.add(styleAttr);
+                    }
+                    if (repeatStyleAttr.contains(styleAttr)) {
+                        Attribute format = attr.attribute(StyleAttr.ATTR_FORMAT);
+                        attr.remove(format);
+                    }
+                }
+            }
 
             // 只保留第一个attr的定义
             for (Element declareStyle : styleableElements) {

--- a/source/src/main/java/com/kezong/fataar/ValuesHelper.java
+++ b/source/src/main/java/com/kezong/fataar/ValuesHelper.java
@@ -15,26 +15,19 @@ import org.gradle.api.Project;
 
 
 public class ValuesHelper {
-    private static ValuesHelper sInstance = null;
-    private Project mProject;
+    private static Project mProject;
     private static final String ELE_ATTR = "attr";
     private static final String ELE_DECLARE_STYLEABLE = "declare-styleable";
 
-    public static ValuesHelper getInstance() {
-        if (sInstance == null) {
-            sInstance = new ValuesHelper();
-        }
-        return sInstance;
-    }
-
-    public void init(Project project) {
+    public static void attach(Project project) {
         // fix: org.xml.sax.SAXNotRecognizedException: unrecognized feature http://xml.org/sax/features/external-general-entities
         System.setProperty("javax.xml.parsers.SAXParserFactory",
                 "com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl");
         mProject = project;
+        project.getLogger().info("attach Values Helper");
     }
 
-    public void splitValuesXmlRepeatAttr(File pkgFile) {
+    public static void splitValuesXmlRepeatAttr(File pkgFile) {
 
         final File valueXml = new File(pkgFile, "res/values/values.xml");
         if (!valueXml.exists()) {
@@ -48,7 +41,7 @@ public class ValuesHelper {
         }
     }
 
-    private void formatRepeatAttr(final File file) {
+    private static void formatRepeatAttr(final File file) {
         try {
             mProject.getLogger()
                     .info("ValuesHelper: deleteDuplicateAttr : " + file.getAbsolutePath());


### PR DESCRIPTION
在 android.disableResourceValidation=true的时候
多个依赖中存在 declare-styleable 中重复声明了同一个attr，
导致使用打出来的aar会提示—Error: Found item Attr/** more than one time，

这个问题本该在assemble aar的时候由duplicate resource暴露，但是因为disableResourceValidation的缘故，会导致最终的aar包里res/values/出现类似以下定义，会在最终打包成apk的时候出现Error: Found item Attr/** more than one time
```xml
 <declare-styleable name="DeclareStyleableDefault">
    <attr format="color" name="exampleTextColor"/>
    <attr format="color" name="exampleBackground"/>
  </declare-styleable>
  <declare-styleable name="DeclareStyleableNew">
    <attr format="color" name="exampleTextColor"/>
    <attr format="color" name="exampleTintTitle"/>
  </declare-styleable>
```
期望的正确写法应该是, <attr format="color" name="exampleTextColor"/>只被声明一次，如下
```xml
 <declare-styleable name="DeclareStyleableDefault">
    <attr format="color" name="exampleTextColor"/>
    <attr format="color" name="exampleBackground"/>
  </declare-styleable>
  <declare-styleable name="DeclareStyleableNew">
    <attr name="exampleTextColor" />
    <attr format="color" name="exampleTintTitle"/>
  </declare-styleable>
  ```
