### PR TITLE
Fix "Could not copy zip entry … Permission Denied" errors

### DIFF
--- a/source/src/main/groovy/com/kezong/fataar/ExplodedHelper.groovy
+++ b/source/src/main/groovy/com/kezong/fataar/ExplodedHelper.groovy
@@ -58,6 +58,8 @@ class ExplodedHelper {
             project.copy {
                 from project.zipTree(jarFile)
                 into folderOut
+                dirMode 0755
+                fileMode 0755
             }
         }
     }
@@ -86,6 +88,8 @@ class ExplodedHelper {
                 from project.zipTree(jarFile)
                 into folderOut
                 exclude 'META-INF/'
+                dirMode 0755
+                fileMode 0755
             }
         }
     }


### PR DESCRIPTION
On systems where unzipping an archive restores the file permissions, if the original file permissions are too restrictive, the copy task fails.

For example:
```
Execution failed for task ':module:mergeClassesRelease'.
> Could not copy zip entry …/module/build/intermediates/exploded-aar/androidx.benchmark/benchmark-macro-junit4/1.1.0-rc02/release/classes.jar!META-INF/androidx.benchmark_benchmark-macro-junit4.version to '…/module/build/intermediates/fat-aar/merge_classes/release/META-INF/androidx.benchmark_benchmark-macro-junit4.version'.
   > …/module/build/intermediates/fat-aar/merge_classes/release/META-INF/androidx.benchmark_benchmark-macro-junit4.version (Permission denied)
```