### PR TITLE
fix missing resources when using AGP 7.3.X 

### DIFF
--- a/source/src/main/groovy/com/kezong/fataar/VariantProcessor.groovy
+++ b/source/src/main/groovy/com/kezong/fataar/VariantProcessor.groovy
@@ -472,13 +472,11 @@ class VariantProcessor {
         resourceGenTask.configure {
             dependsOn(mExplodeTasks)
 
-            mProject.android.sourceSets.each { DefaultAndroidSourceSet sourceSet ->
-                if (sourceSet.name == mVariant.name) {
-                    for (archiveLibrary in mAndroidArchiveLibraries) {
-                        FatUtils.logInfo("Merge resource，Library res：${archiveLibrary.resFolder}")
-                        sourceSet.res.srcDir(archiveLibrary.resFolder)
-                    }
-                }
+            for (archiveLibrary in mAndroidArchiveLibraries) {
+                FatUtils.logInfo("Merge resource，Library res：${archiveLibrary.resFolder}")
+                mVariant.registerGeneratedResFolders(
+                        mProject.files(archiveLibrary.resFolder)
+                )
             }
         }
     }


### PR DESCRIPTION
## Fixes 
- https://github.com/kezong/fat-aar-android/issues/402
- https://github.com/kezong/fat-aar-android/issues/399

## Changelog
- use registerGeneratedResFolders to merge resources

## Use the fixed version in your project
Until this MR gets merged you need to use [jitpack](https://jitpack.io/) to get a version of the library that includes this fix.
I created a new branch for this because i also had to modify the publishing config: https://github.com/AndreasBoehm/fat-aar-android/tree/fix-missing-resources-jitpack

Details can be found here: https://jitpack.io/#AndreasBoehm/fat-aar-android/da3ac00990