### PR TITLE
Fix wrong build path when building multiple modules together.

### DIFF
--- a/source/src/main/groovy/com/kezong/fataar/DirectoryManager.groovy
+++ b/source/src/main/groovy/com/kezong/fataar/DirectoryManager.groovy
@@ -13,33 +13,27 @@ class DirectoryManager {
 
     private static final String INTERMEDIATES_TEMP_FOLDER = "fat-aar";
 
-    private static Project sProject;
-
-    static void attach(Project project) {
-        sProject = project;
+    static File getReBundleDirectory(Project project, LibraryVariant variant) {
+        return project.file("${project.getBuildDir()}/outputs/${RE_BUNDLE_FOLDER}/${variant.name}")
     }
 
-    static File getReBundleDirectory(LibraryVariant variant) {
-        return sProject.file("${sProject.getBuildDir()}/outputs/${RE_BUNDLE_FOLDER}/${variant.name}")
+    static File getRJavaDirectory(Project project, LibraryVariant variant) {
+        return project.file("${project.getBuildDir()}/intermediates/${INTERMEDIATES_TEMP_FOLDER}/r/${variant.name}")
     }
 
-    static File getRJavaDirectory(LibraryVariant variant) {
-        return sProject.file("${sProject.getBuildDir()}/intermediates/${INTERMEDIATES_TEMP_FOLDER}/r/${variant.name}")
+    static File getRClassDirectory(Project project, LibraryVariant variant) {
+        return project.file("${project.getBuildDir()}/intermediates/${INTERMEDIATES_TEMP_FOLDER}/r-class/${variant.name}")
     }
 
-    static File getRClassDirectory(LibraryVariant variant) {
-        return sProject.file("${sProject.getBuildDir()}/intermediates/${INTERMEDIATES_TEMP_FOLDER}/r-class/${variant.name}")
+    static File getRJarDirectory(Project project, LibraryVariant variant) {
+        return project.file("${project.getBuildDir()}/outputs/${RE_BUNDLE_FOLDER}/${variant.name}/libs")
     }
 
-    static File getRJarDirectory(LibraryVariant variant) {
-        return sProject.file("${sProject.getBuildDir()}/outputs/${RE_BUNDLE_FOLDER}/${variant.name}/libs")
+    static File getMergeClassDirectory(Project project, LibraryVariant variant) {
+        return project.file("${project.getBuildDir()}/intermediates/${INTERMEDIATES_TEMP_FOLDER}/merge_classes/${variant.name}")
     }
 
-    static File getMergeClassDirectory(LibraryVariant variant) {
-        return sProject.file("${sProject.getBuildDir()}/intermediates/${INTERMEDIATES_TEMP_FOLDER}/merge_classes/${variant.name}")
-    }
-
-    static File getKotlinMetaDirectory(LibraryVariant variant) {
-        return sProject.file("${sProject.getBuildDir()}/tmp/kotlin-classes/${variant.name}/META-INF")
+    static File getKotlinMetaDirectory(Project project, LibraryVariant variant) {
+        return project.file("${project.getBuildDir()}/tmp/kotlin-classes/${variant.name}/META-INF")
     }
 }

--- a/source/src/main/groovy/com/kezong/fataar/FatAarPlugin.groovy
+++ b/source/src/main/groovy/com/kezong/fataar/FatAarPlugin.groovy
@@ -32,7 +32,6 @@ class FatAarPlugin implements Plugin<Project> {
         this.project = project
         checkAndroidPlugin()
         FatUtils.attach(project)
-        DirectoryManager.attach(project)
         project.extensions.create(FatAarExtension.NAME, FatAarExtension)
         createConfigurations()
         registerTransform()

--- a/source/src/main/groovy/com/kezong/fataar/RClassesGenerate.groovy
+++ b/source/src/main/groovy/com/kezong/fataar/RClassesGenerate.groovy
@@ -29,9 +29,9 @@ class RClassesGenerate {
     }
 
     TaskProvider configure(TaskProvider<Task> reBundleTask) {
-        File rJavaDir = DirectoryManager.getRJavaDirectory(mVariant)
-        File rClassDir = DirectoryManager.getRClassDirectory(mVariant)
-        File rJarDir = DirectoryManager.getRJarDirectory(mVariant)
+        File rJavaDir = DirectoryManager.getRJavaDirectory(mProject, mVariant)
+        File rClassDir = DirectoryManager.getRClassDirectory(mProject, mVariant)
+        File rJarDir = DirectoryManager.getRJarDirectory(mProject, mVariant)
         def RJarTask = configureRJarTask(rClassDir, rJarDir, reBundleTask)
         def RClassTask = configureRClassTask(rJavaDir, rClassDir, RJarTask)
         def RFileTask = configureRFileTask(rJavaDir, RClassTask)

--- a/source/src/main/groovy/com/kezong/fataar/VariantProcessor.groovy
+++ b/source/src/main/groovy/com/kezong/fataar/VariantProcessor.groovy
@@ -132,7 +132,7 @@ class VariantProcessor {
 
     private TaskProvider configureReBundleAarTask(TaskProvider bundleTask) {
         File aarOutputFile
-        File reBundleDir = DirectoryManager.getReBundleDirectory(mVariant)
+        File reBundleDir = DirectoryManager.getReBundleDirectory(mProject, mVariant)
         bundleTask.configure { it ->
             if (FatUtils.compareVersion(mProject.gradle.gradleVersion, "5.1") >= 0) {
                 aarOutputFile = new File(it.getDestinationDirectory().getAsFile().get(), it.getArchiveFileName().get())
@@ -225,7 +225,7 @@ class VariantProcessor {
             doLast {
                 for (archiveLibrary in mAndroidArchiveLibraries) {
                     if (archiveLibrary.dataBindingFolder != null && archiveLibrary.dataBindingFolder.exists()) {
-                        String filePath = "${DirectoryManager.getReBundleDirectory(mVariant).path}/${archiveLibrary.dataBindingFolder.name}"
+                        String filePath = "${DirectoryManager.getReBundleDirectory(mProject, mVariant).path}/${archiveLibrary.dataBindingFolder.name}"
                         new File(filePath).mkdirs()
                         mProject.copy {
                             from archiveLibrary.dataBindingFolder
@@ -234,7 +234,7 @@ class VariantProcessor {
                     }
 
                     if (archiveLibrary.dataBindingLogFolder != null && archiveLibrary.dataBindingLogFolder.exists()) {
-                        String filePath = "${DirectoryManager.getReBundleDirectory(mVariant).path}/${archiveLibrary.dataBindingLogFolder.name}"
+                        String filePath = "${DirectoryManager.getReBundleDirectory(mProject, mVariant).path}/${archiveLibrary.dataBindingLogFolder.name}"
                         new File(filePath).mkdirs()
                         mProject.copy {
                             from archiveLibrary.dataBindingLogFolder
@@ -370,7 +370,7 @@ class VariantProcessor {
                         .withPathSensitivity(PathSensitivity.RELATIVE)
                 inputs.files(mJarFiles).withPathSensitivity(PathSensitivity.RELATIVE)
             }
-            File outputDir = DirectoryManager.getMergeClassDirectory(mVariant)
+            File outputDir = DirectoryManager.getMergeClassDirectory(mProject, mVariant)
             File javacDir = mVersionAdapter.getClassPathDirFiles().first()
             outputs.dir(outputDir)
 
@@ -401,7 +401,7 @@ class VariantProcessor {
 
                 mProject.copy {
                     from outputDir.absolutePath + "/META-INF"
-                    into DirectoryManager.getKotlinMetaDirectory(mVariant)
+                    into DirectoryManager.getKotlinMetaDirectory(mProject, mVariant)
                     include '*.kotlin_module'
                 }
             }


### PR DESCRIPTION
Project information is saved in the DirectoryManager when the plug-in is initialised. However, when there are multiple modules built together, DirectoryManager doesn't sense that the Project has changed, resulting in getting the wrong build path.
So we should pass the information of the currently built Project when we get the build directory, instead of using the initialised Project.